### PR TITLE
Component removal and view updates on component insertion

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,14 +58,16 @@ Running the benchmark can be done as follows:
 # go to the build directory if you aren't there already
 cd build
 
-./benchmark_test
+# you need to specify how many entities to create. In this example, 100 entities are created
+./benchmark_test 100
 ```
 
-You can specify the number of entities to be used in the benchmark test through a command line argument.
-For example, the following command runs the benchmark test with 500 entities:
+You can also specify the number of entities that should have a component removed and added back in.
+This is useful for benchmarking `Each(...)` performance with entities whose number of components change frequently.
+For example, the following command runs the benchmark test with 100 entities, where 50 of those 100 entities have a component removed and added back in:
 
 ```
-./benchmark_test 500
+./benchmark_test 100 50
 ```
 
 #### Memory test

--- a/README.md
+++ b/README.md
@@ -108,14 +108,6 @@ Run the command specified to inspect memory usage.
 
 At the time of this writing, the ECM implemented in this repository is header-only.
 
-Since this is a simple ECM, there are a few limitations:
-1. There's no support for entity/component removal (only adding entities and components are currently supported).
-2. Views are not updated after they are created.
-So, if you create an entity with a set of components _after_ creating a view with this set of components, this new entity is not added to the view.
-In other words, the view only contains entity and component data that existed at the view's creation time.
-
-The limitations above aren't difficult to address, but I have decided not to implement these features at the moment since this is a simple ECM.
-
 ### Components
 
 Components must inherit from `BaseComponent`, and need to have a unique ID.

--- a/include/simpleECM/Components.hh
+++ b/include/simpleECM/Components.hh
@@ -21,6 +21,10 @@ struct BaseComponent
     return _comp.ToOStream(_os);
   }
 
+  /// \brief Get the derived component's typeId
+  /// \return The typeId of the derived component
+  public: virtual ComponentTypeId DerivedTypeId() const = 0;
+
   public: constexpr const static ComponentTypeId typeId{kInvalidComponent};
 };
 
@@ -31,6 +35,11 @@ struct Name : public BaseComponent
   {
     _os << this->name;
     return _os;
+  }
+
+  public: ComponentTypeId DerivedTypeId() const
+  {
+    return this->typeId;
   }
 
   public: std::string name;
@@ -44,6 +53,11 @@ struct World : public BaseComponent
   {
     _os << "This is a world";
     return _os;
+  }
+
+  public: ComponentTypeId DerivedTypeId() const
+  {
+    return this->typeId;
   }
 
   public: constexpr const static ComponentTypeId typeId{2};
@@ -61,6 +75,11 @@ struct Static : public BaseComponent
     return _os;
   }
 
+  public: ComponentTypeId DerivedTypeId() const
+  {
+    return this->typeId;
+  }
+
   public: bool isStatic;
   public: constexpr const static ComponentTypeId typeId{3};
 };
@@ -74,6 +93,11 @@ struct Position : public BaseComponent
     return _os;
   }
 
+  public: ComponentTypeId DerivedTypeId() const
+  {
+    return this->typeId;
+  }
+
   public: Vector3i data;
   public: constexpr const static ComponentTypeId typeId{4};
 };
@@ -81,6 +105,11 @@ struct Position : public BaseComponent
 /// \brief A component representing an entity's position in world coordinates
 struct WorldPosition : public Position
 {
+  public: ComponentTypeId DerivedTypeId() const
+  {
+    return this->typeId;
+  }
+
   public: constexpr const static ComponentTypeId typeId{5};
 };
 
@@ -93,6 +122,11 @@ struct LinearVelocity : public BaseComponent
     return _os;
   }
 
+  public: ComponentTypeId DerivedTypeId() const
+  {
+    return this->typeId;
+  }
+
   public: Vector3i data;
   public: constexpr const static ComponentTypeId typeId{6};
 };
@@ -101,6 +135,11 @@ struct LinearVelocity : public BaseComponent
 /// coordinates
 struct WorldLinearVelocity : public LinearVelocity
 {
+  public: ComponentTypeId DerivedTypeId() const
+  {
+    return this->typeId;
+  }
+
   public: constexpr const static ComponentTypeId typeId{7};
 };
 
@@ -113,6 +152,11 @@ struct AngularVelocity : public BaseComponent
     return _os;
   }
 
+  public: ComponentTypeId DerivedTypeId() const
+  {
+    return this->typeId;
+  }
+
   public: Vector3i data;
   public: constexpr const static ComponentTypeId typeId{8};
 };
@@ -121,6 +165,11 @@ struct AngularVelocity : public BaseComponent
 /// coordinates
 struct WorldAngularVelocity : public AngularVelocity
 {
+  public: ComponentTypeId DerivedTypeId() const
+  {
+    return this->typeId;
+  }
+
   public: constexpr const static ComponentTypeId typeId{9};
 };
 
@@ -133,6 +182,11 @@ struct LinearAcceleration : public BaseComponent
     return _os;
   }
 
+  public: ComponentTypeId DerivedTypeId() const
+  {
+    return this->typeId;
+  }
+
   public: Vector3i data;
   public: constexpr const static ComponentTypeId typeId{10};
 };
@@ -141,6 +195,11 @@ struct LinearAcceleration : public BaseComponent
 /// coordinates
 struct WorldLinearAcceleration : public LinearAcceleration
 {
+  public: ComponentTypeId DerivedTypeId() const
+  {
+    return this->typeId;
+  }
+
   public: constexpr const static ComponentTypeId typeId{11};
 };
 
@@ -153,6 +212,11 @@ struct Pose : public BaseComponent
     return _os;
   }
 
+  public: ComponentTypeId DerivedTypeId() const
+  {
+    return this->typeId;
+  }
+
   public: Vector3i position;
   public: Quaternioni orientation;
   public: constexpr const static ComponentTypeId typeId{12};
@@ -161,6 +225,11 @@ struct Pose : public BaseComponent
 /// \brief A component representing an entity's pose in world coordinates
 struct WorldPose : public Pose
 {
+  public: ComponentTypeId DerivedTypeId() const
+  {
+    return this->typeId;
+  }
+
   public: constexpr const static ComponentTypeId typeId{13};
 };
 

--- a/include/simpleECM/Ecm.hh
+++ b/include/simpleECM/Ecm.hh
@@ -163,7 +163,7 @@ void ECM::RemoveComponent(const Entity &_entity)
   // remove the entity from the views that have this component
   for (auto &[compTypes, view] : this->views)
   {
-    if (!this->HasAllComponents(_entity, compTypes))
+    if (view->HasComponent(ComponentTypeT::typeId))
       view->RemoveEntity(_entity);
   }
 }

--- a/include/simpleECM/Ecm.hh
+++ b/include/simpleECM/Ecm.hh
@@ -130,7 +130,8 @@ void ECM::AddComponent(const Entity &_entity, const ComponentTypeT &_component)
 
   for (auto &[compTypes, view] : this->views)
   {
-    if (this->HasAllComponents(_entity, compTypes))
+    if (!view->HasEntity(_entity) && !view->HasNewEntity(_entity) &&
+        this->HasAllComponents(_entity, compTypes))
       view->AddNewEntity(_entity);
   }
 }

--- a/include/simpleECM/Ecm.hh
+++ b/include/simpleECM/Ecm.hh
@@ -25,6 +25,11 @@ class ECM
           void AddComponent(const Entity &_entity,
               const ComponentTypeT &_component);
 
+  /// \brief Remove a component from an entity
+  /// \param[in] _entity The entity
+  public: template<typename ComponentTypeT>
+          void RemoveComponent(const Entity &_entity);
+
   /// \brief Execute a callback function on each entity with a set of components
   /// \param[in] _f The callback function to be executed
   public: template<typename ...ComponentTypeTs>
@@ -55,9 +60,17 @@ class ECM
   private: template<typename ComponentTypeT>
            ComponentTypeT *Component(const Entity &_entity) const;
 
+  /// \brief See if an entity has a list of component types
+  /// \param[in] _entity The entity
+  /// \param[in] _compTypes The types of components
+  /// \return true if _entity has each type of component in _compTypes, false
+  /// otherwise
+  private: bool HasAllComponents(const Entity &_entity,
+               const std::vector<ComponentTypeId> &_compTypes) const;
+
   /// \brief A map of an Entity to its components
   private: std::unordered_map<Entity,
-            std::vector<std::unique_ptr<BaseComponent>>> entityComponents;
+            std::vector<std::shared_ptr<BaseComponent>>> entityComponents;
 
   /// \brief A map that keeps track of where each type of component is located
   /// in the this->entityComponents vector. Since the this->entityComponents
@@ -112,8 +125,47 @@ void ECM::AddComponent(const Entity &_entity, const ComponentTypeT &_component)
   auto entityCompIter = this->entityComponents.find(_entity);
   auto vectorIdx = entityCompIter->second.size();
   entityCompIter->second.push_back(
-      std::make_unique<ComponentTypeT>(_component));
+      std::make_shared<ComponentTypeT>(_component));
   this->componentTypeIndex[_entity][ComponentTypeT::typeId] = vectorIdx;
+
+  for (auto &[compTypes, view] : this->views)
+  {
+    if (this->HasAllComponents(_entity, compTypes))
+      view->AddNewEntity(_entity);
+  }
+}
+
+
+template<typename ComponentTypeT>
+void ECM::RemoveComponent(const Entity &_entity)
+{
+  if (!this->HasComponent(_entity, ComponentTypeT::typeId))
+    return;
+
+  // remove the component
+  //  - if the component to remove is the last component in the entity's vector
+  //    of components, simply pop off the last component from the vector
+  //  - if the component to remove is not the last component in the entity's
+  //    vector of components, swap it with the last component in the vector and
+  //    then pop off the last component in the vector
+  const auto removalCompIdx =
+    this->componentTypeIndex[_entity][ComponentTypeT::typeId];
+  if (removalCompIdx != (this->entityComponents[_entity].size() - 1))
+  {
+    const auto lastBaseComp = this->entityComponents[_entity].back();
+    this->componentTypeIndex[_entity][lastBaseComp->DerivedTypeId()] =
+      removalCompIdx;
+    this->entityComponents[_entity][removalCompIdx] = lastBaseComp;
+  }
+  this->entityComponents[_entity].pop_back();
+  this->componentTypeIndex[_entity].erase(ComponentTypeT::typeId);
+
+  // remove the entity from the views that have this component
+  for (auto &[compTypes, view] : this->views)
+  {
+    if (!this->HasAllComponents(_entity, compTypes))
+      view->RemoveEntity(_entity);
+  }
 }
 
 template<typename ...ComponentTypeTs>
@@ -137,12 +189,21 @@ std::size_t ECM::ViewCount() const
 template<typename ...ComponentTypeTs>
 View<ComponentTypeTs...> *ECM::FindView()
 {
-  auto viewKey = std::vector<ComponentTypeId> {ComponentTypeTs::typeId...};
+  std::vector<ComponentTypeId> viewKey {ComponentTypeTs::typeId...};
 
   // does the view already exist?
   auto iter = this->views.find(viewKey);
   if (iter != this->views.end())
-    return static_cast<View<ComponentTypeTs...>*>((iter->second).get());
+  {
+    auto view = static_cast<View<ComponentTypeTs...>*>((iter->second).get());
+
+    // add any new entities to the view before using it
+    for (const auto &entity : view->NewEntities())
+      view->AddEntity(entity, this->Component<ComponentTypeTs>(entity)...);
+    view->RemoveNewEntities();
+
+    return view;
+  }
 
   // create a new view if one wasn't found
   View<ComponentTypeTs...> view;
@@ -152,17 +213,7 @@ View<ComponentTypeTs...> *ECM::FindView()
   {
     const auto entity = entityCompData.first;
 
-    bool hasAllComponentTypes = true;
-    for (const auto &compType : viewKey)
-    {
-      if (!this->HasComponent(entity, compType))
-      {
-        hasAllComponentTypes = false;
-        break;
-      }
-    }
-
-    if (!hasAllComponentTypes)
+    if (!this->HasAllComponents(entity, viewKey))
       continue;
 
     view.AddEntity(entity, this->Component<ComponentTypeTs>(entity)...);
@@ -192,6 +243,18 @@ ComponentTypeT *ECM::Component(const Entity &_entity) const
   const auto baseCompPtr =
     this->entityComponents.at(_entity).at(componentIdx).get();
   return static_cast<ComponentTypeT*>(baseCompPtr);
+}
+
+bool ECM::HasAllComponents(const Entity &_entity,
+    const std::vector<ComponentTypeId> &_compTypes) const
+{
+  for (const auto &type : _compTypes)
+  {
+    if (!this->HasComponent(_entity, type))
+      return false;
+  }
+
+  return true;
 }
 
 #endif

--- a/include/simpleECM/View.hh
+++ b/include/simpleECM/View.hh
@@ -1,9 +1,9 @@
 #ifndef VIEW_HH_
 #define VIEW_HH_
 
-#include <unordered_set>
 #include <tuple>
 #include <unordered_map>
+#include <unordered_set>
 
 #include "simpleECM/Types.hh"
 
@@ -40,10 +40,19 @@ class BaseView
   }
 
   /// \brief Remove all of the new entities from the view. This should be called
-  /// after each new entity's component data has been added to the view
+  /// after all of the new entity component data has been added to the view
   public: void RemoveNewEntities()
   {
     this->newEntities.clear();
+  }
+
+  /// \brief See if the view holds data of a particular component type
+  /// \param[in] _typeId The component type
+  /// \return true if the view has component data of type _typeId, false
+  /// otherwise
+  public: bool virtual HasComponent(const ComponentTypeId &_typeId) const
+  {
+    return this->compTypes.find(_typeId) != this->compTypes.end();
   }
 
   /// \brief Destructor
@@ -56,12 +65,21 @@ class BaseView
 
   /// \brief The entities in the view
   protected: std::unordered_set<Entity> entities;
+
+  /// \brief The component types in the view
+  protected: std::unordered_set<ComponentTypeId> compTypes;
 };
 
 template<typename ...ComponentTypeTs>
 class View : public BaseView
 {
   private: using ComponentData = std::tuple<Entity, ComponentTypeTs*...>;
+
+  /// \brief Constructor
+  public: View()
+  {
+    this->compTypes = {ComponentTypeTs::typeId...};
+  }
 
   /// \brief Get an entity and its component data. It is assumed that the
   /// entity being requested exists in the view

--- a/include/simpleECM/View.hh
+++ b/include/simpleECM/View.hh
@@ -16,6 +16,22 @@ class BaseView
     return this->entities;
   }
 
+  /// \brief Check if an entity is a part of the view
+  /// \param[in] _entity The entity
+  /// \return true if _entity is a part of the view, false otherwise
+  public: bool HasEntity(const Entity &_entity) const
+  {
+    return this->entities.find(_entity) != this->entities.end();
+  }
+
+  /// \brief Check if an entity is marked as an entity to be added to the view
+  /// \param[in] _entity The entity
+  /// \return true if _entity is to be added to the view, false otherwise
+  public: bool HasNewEntity(const Entity &_entity) const
+  {
+    return this->newEntities.find(_entity) != this->newEntities.end();
+  }
+
   /// \brief Remove an entity from the view, whether it's an entity that already
   /// exists in the view or is a new entity to be added to the view
   /// \param[in] _entity The entity
@@ -29,14 +45,13 @@ class BaseView
   }
 
   /// \brief Add a new entity to the view. This entity's component data should
-  /// be added to the view the next time the view is being used. If the new
-  /// entity being added already exists in the view, then this new entity is
-  /// ignored
+  /// be added to the view the next time the view is being used. It is assumed
+  /// that this new entity isn't already associated with the view
   /// \param[in] _entity The new entity
+  /// \sa HasEntity HasNewEntity
   public: void AddNewEntity(const Entity &_entity)
   {
-    if (this->entities.find(_entity) == this->entities.end())
-      this->newEntities.insert(_entity);
+    this->newEntities.insert(_entity);
   }
 
   /// \brief Remove all of the new entities from the view. This should be called

--- a/src/main.cc
+++ b/src/main.cc
@@ -1,17 +1,22 @@
 #include <functional>
 #include <iostream>
+#include <vector>
 
 #include "simpleECM/Components.hh"
 #include "simpleECM/Ecm.hh"
+#include "simpleECM/Types.hh"
 
 int main()
 {
+  std::vector<Entity> entities;
+
   ECM ecm;
 
   // create a few entities that have components
   for (auto i = 0; i < 3; ++i)
   {
     auto entity = ecm.CreateEntity();
+    entities.push_back(entity);
 
     Position position;
     position.data.x = i;
@@ -99,6 +104,32 @@ int main()
   std::cout << "Done updating component data" << std::endl << std::endl
     << "-----" << std::endl << std::endl;
   ecm.Each(printAllUpdatedComponents);
+
+  // remove components from the first entity to see how views are updated
+  std::cout << std::endl << "-----" << std::endl << std::endl
+    << "Removing the following components:" << std::endl
+    << "\t- position component from Entity " << entities[0] << std::endl
+    << "\t- linear velocity component from Entity " << entities[1] << std::endl
+    << "\t- linear acceleration component from Entity " << entities[2]
+    << std::endl;
+  ecm.RemoveComponent<Position>(entities[0]);
+  ecm.RemoveComponent<LinearVelocity>(entities[1]);
+  ecm.RemoveComponent<LinearAcceleration>(entities[2]);
+  std::cout << "Done removing the components" << std::endl << std::endl
+    << "-----" << std::endl << std::endl;
+  std::cout << "The following entities have position, linear velocity, and "
+    << "linear acceleration components:" << std::endl;
+  ecm.Each(printAllComponents);
+
+  // add components back in and check the views again
+  std::cout << std::endl << "-----" << std::endl << std::endl
+    << "Re-creating the components that were just removed..." << std::endl;
+  ecm.AddComponent<Position>(entities[0], Position());
+  ecm.AddComponent<LinearVelocity>(entities[1], LinearVelocity());
+  ecm.AddComponent<LinearAcceleration>(entities[2], LinearAcceleration());
+  std::cout << "Done adding back in the components" << std::endl << std::endl
+    << "-----" << std::endl << std::endl;
+  ecm.Each(printAllComponents);
 
   // verify that the ECM has 5 views (5 callback functions were used, with each
   // CB having a unique order of component types in the method signature)

--- a/src/main.cc
+++ b/src/main.cc
@@ -79,6 +79,14 @@ int main()
       return true;
     };
 
+  std::function<bool(const Entity &, Position *, LinearVelocity *)> posLinVel =
+    [](const Entity &_entity, Position *, LinearVelocity *) -> bool
+    {
+      std::cout << "Entity " << _entity
+        << " has a position and linear velocity component" << std::endl;
+      return true;
+    };
+
   // this callback function does the same thing as printAllComponents,
   // but requests the entities in a different order and therefore uses a
   // different view
@@ -120,6 +128,8 @@ int main()
   std::cout << "The following entities have position, linear velocity, and "
     << "linear acceleration components:" << std::endl;
   ecm.Each(printAllComponents);
+  std::cout << std::endl << "-----" << std::endl << std::endl;
+  ecm.Each(posLinVel);
 
   // add components back in and check the views again
   std::cout << std::endl << "-----" << std::endl << std::endl
@@ -131,7 +141,20 @@ int main()
     << "-----" << std::endl << std::endl;
   ecm.Each(printAllComponents);
 
-  // verify that the ECM has 5 views (5 callback functions were used, with each
+  // create a brand new component to make sure it's added to the appropriate
+  // views
+  std::cout << std::endl << "-----" << std::endl << std::endl
+    << "Creating a new entity with position and linear velocity components..."
+    << std::endl;
+  auto entity = ecm.CreateEntity();
+  entities.push_back(entity);
+  ecm.AddComponent<Position>(entity, Position());
+  ecm.AddComponent<LinearVelocity>(entity, LinearVelocity());
+  std::cout << "Done creating the new entity" << std::endl << std::endl
+    << "-----" << std::endl << std::endl;
+  ecm.Each(posLinVel);
+
+  // verify that the ECM has 6 views (6 callback functions were used, with each
   // CB having a unique order of component types in the method signature)
   std::cout << std::endl << "-----" << std::endl << std::endl
     << "The ECM has " << ecm.ViewCount() << " views" << std::endl;

--- a/test/each_benchmark.cc
+++ b/test/each_benchmark.cc
@@ -108,7 +108,7 @@ int main(int argc, char **argv)
     {
       std::cout << std::endl;
 
-      // remove components from entities, and then call each a few times
+      // remove components from entities, and then call Each(...) a few times
       benchmarkRunner->StartTimer();
       benchmarkRunner->RemoveAComponent();
       benchmarkRunner->StopTimer();
@@ -128,7 +128,7 @@ int main(int argc, char **argv)
       }
       std::cout << std::endl;
 
-      // add components to entities, and then call each a few times
+      // add components to entities, and then call Each(...) a few times
       benchmarkRunner->StartTimer();
       benchmarkRunner->AddAComponent();
       benchmarkRunner->StopTimer();

--- a/test/each_benchmark.cc
+++ b/test/each_benchmark.cc
@@ -8,12 +8,42 @@
 
 int main(int argc, char **argv)
 {
-  // users may specify the number of entities they'd like to spawn from the
-  // command line
-  int numEntities = 100;
-  if (argc == 2)
+  // command line arguments are as follows:
+  //  * the number of entities to create (required)
+  //  * the number of entities that should have a component added/removed
+  //    in between Each calls (optional). If this argument is not specified,
+  //    no components will be added/removed from entities between Each calls
+  int numEntitiesCreated = 0;
+  int numEntitiesAddRemoveComp = 0;
+  bool addAndRemoveComps = false;
+  if (argc >= 2)
   {
-    numEntities = std::stoi(argv[1]);
+    numEntitiesCreated = std::stoi(argv[1]);
+    if (argc == 3)
+    {
+      numEntitiesAddRemoveComp = std::stoi(argv[2]);
+      addAndRemoveComps = true;
+      if (numEntitiesAddRemoveComp > numEntitiesCreated)
+      {
+        std::cerr << numEntitiesCreated
+          << " entities are requested to be created, but "
+          << numEntitiesAddRemoveComp
+          << " entities should have components added/removed."
+          << std::endl << "This isn't possible!" << std::endl;
+        return -1;
+      }
+    }
+  }
+  else
+  {
+    const std::string entityCreationStr = "<# of entities to create>";
+    const std::string entityAddRemoveCompStr =
+      "[# of entities to add/remove components]";
+    std::cerr << "Usage: " << argv[0] << entityCreationStr << " "
+      << entityAddRemoveCompStr << std::endl << std::endl
+      << entityAddRemoveCompStr << " should be <= than " << entityCreationStr
+      << std::endl;
+    return -1;
   }
 
   // all of the ECM implementations that will be benchmarked
@@ -38,14 +68,11 @@ int main(int argc, char **argv)
   //  pose
   //  world pose
   const int numComponents = 10;
-  std::cout << "Creating an ECM with " << numEntities << " entities, with "
+  std::cout << "Creating an ECM with " << numEntitiesCreated << " entities, with "
     << numComponents << " components per entity" << std::endl;
 
   // the number of times we will call Each(...) on the ECM
   const int numEachCalls = 3;
-  std::cout << "Calling Each(...) " << numEachCalls << " times, searching for "
-    << numEntities << " entities with " << numComponents
-    << " components in every Each(...) call" << std::endl << std::endl;
 
   for (std::size_t typeIdx = 0; typeIdx < implementationTypes.size(); ++typeIdx)
   {
@@ -53,28 +80,71 @@ int main(int argc, char **argv)
     auto benchmarkRunner = BenchmarkRunnerFactory::Create(ecmType);
     if (!benchmarkRunner)
       continue;
-    std::cout << ecmType << " implementation" << std::endl << std::endl;
+    std::cout << std::endl << "-----" << std::endl << std::endl
+      << ecmType << " implementation" << std::endl << std::endl;
 
     // instantiate the ecm and populate it with entities/components
-    benchmarkRunner->Init();
-    for (auto i = 0; i < numEntities; ++i)
+    benchmarkRunner->Init(numEntitiesAddRemoveComp);
+    for (auto i = 0; i < numEntitiesCreated; ++i)
       benchmarkRunner->MakeEntityWithComponents();
 
     // call Each(...) a few times and see how long it takes to find the entities
     // with all of the defined components (this first Each(...) call should take
     // the longest since it has to create the view - once the view is created,
     // subsequent Each(...) calls should be noticeably faster)
+    std::cout << "Calling Each(...) " << numEachCalls  << " times on "
+      << numEntitiesCreated << " created entities, with " << numComponents
+      << " components per entity" << std::endl;
     for (auto i = 0; i < numEachCalls; ++i)
     {
       benchmarkRunner->StartTimer();
       benchmarkRunner->EachImplementation();
       benchmarkRunner->StopTimer();
-      if (benchmarkRunner->Valid(numEntities))
+      if (benchmarkRunner->Valid(numEntitiesCreated))
         benchmarkRunner->DisplayElapsedTime();
     }
 
-    if (typeIdx != implementationTypes.size() - 1)
-      std::cout << std::endl << "-----" << std::endl << std::endl;
+    if (addAndRemoveComps)
+    {
+      std::cout << std::endl;
+
+      // remove components from entities, and then call each a few times
+      benchmarkRunner->StartTimer();
+      benchmarkRunner->RemoveAComponent();
+      benchmarkRunner->StopTimer();
+      benchmarkRunner->DisplayElapsedTime("Removing a component from "
+          + std::to_string(numEntitiesAddRemoveComp) + " entities took ");
+      std::cout << "Calling Each(...) " << numEachCalls <<
+        " times on the entities that didn't have a component removed:"
+        << std::endl;
+      for (auto i = 0; i < numEachCalls; ++i)
+      {
+        benchmarkRunner->StartTimer();
+        benchmarkRunner->EachImplementation();
+        benchmarkRunner->StopTimer();
+        if (benchmarkRunner->Valid(
+              numEntitiesCreated - numEntitiesAddRemoveComp))
+          benchmarkRunner->DisplayElapsedTime();
+      }
+      std::cout << std::endl;
+
+      // add components to entities, and then call each a few times
+      benchmarkRunner->StartTimer();
+      benchmarkRunner->AddAComponent();
+      benchmarkRunner->StopTimer();
+      benchmarkRunner->DisplayElapsedTime("Adding a component to "
+          + std::to_string(numEntitiesAddRemoveComp) + " entities took ");
+      std::cout << "Calling Each(...) " << numEachCalls <<
+        " times on the entities that have all components:" << std::endl;
+      for (auto i = 0; i < numEachCalls; ++i)
+      {
+        benchmarkRunner->StartTimer();
+        benchmarkRunner->EachImplementation();
+        benchmarkRunner->StopTimer();
+        if (benchmarkRunner->Valid(numEntitiesCreated))
+          benchmarkRunner->DisplayElapsedTime();
+      }
+    }
 
     delete benchmarkRunner;
     benchmarkRunner = nullptr;

--- a/test/each_benchmark.cc
+++ b/test/each_benchmark.cc
@@ -108,42 +108,35 @@ int main(int argc, char **argv)
     {
       std::cout << std::endl;
 
-      // remove components from entities, and then call Each(...) a few times
-      benchmarkRunner->StartTimer();
-      benchmarkRunner->RemoveAComponent();
-      benchmarkRunner->StopTimer();
-      benchmarkRunner->DisplayElapsedTime("Removing a component from "
-          + std::to_string(numEntitiesAddRemoveComp) + " entities took ");
-      std::cout << "Calling Each(...) " << numEachCalls <<
-        " times on the entities that didn't have a component removed:"
-        << std::endl;
       for (auto i = 0; i < numEachCalls; ++i)
       {
+        // remove components from entities, and then call Each(...)
+        benchmarkRunner->StartTimer();
+        benchmarkRunner->RemoveAComponent();
+        benchmarkRunner->StopTimer();
+        benchmarkRunner->DisplayElapsedTime("Removing a component from "
+            + std::to_string(numEntitiesAddRemoveComp) + " entities: ");
         benchmarkRunner->StartTimer();
         benchmarkRunner->EachImplementation();
         benchmarkRunner->StopTimer();
         if (benchmarkRunner->Valid(
               numEntitiesCreated - numEntitiesAddRemoveComp))
-          benchmarkRunner->DisplayElapsedTime();
-      }
-      std::cout << std::endl;
+          benchmarkRunner->DisplayElapsedTime("Each(...): ");
 
-      // add components to entities, and then call Each(...) a few times
-      benchmarkRunner->StartTimer();
-      benchmarkRunner->AddAComponent();
-      benchmarkRunner->StopTimer();
-      benchmarkRunner->DisplayElapsedTime("Adding a component to "
-          + std::to_string(numEntitiesAddRemoveComp) + " entities took ");
-      std::cout << "Calling Each(...) " << numEachCalls <<
-        " times on the entities that have all components:" << std::endl;
-      for (auto i = 0; i < numEachCalls; ++i)
-      {
+        // add components to entities, and then call Each(...)
+        benchmarkRunner->StartTimer();
+        benchmarkRunner->AddAComponent();
+        benchmarkRunner->StopTimer();
+        benchmarkRunner->DisplayElapsedTime("Adding a component to "
+            + std::to_string(numEntitiesAddRemoveComp) + " entities: ");
         benchmarkRunner->StartTimer();
         benchmarkRunner->EachImplementation();
         benchmarkRunner->StopTimer();
         if (benchmarkRunner->Valid(numEntitiesCreated))
-          benchmarkRunner->DisplayElapsedTime();
+          benchmarkRunner->DisplayElapsedTime("Each(...): ");
       }
+
+      std::cout << std::endl;
     }
 
     delete benchmarkRunner;

--- a/test/include/benchmark/EnttViewBenchmarkRunner.hh
+++ b/test/include/benchmark/EnttViewBenchmarkRunner.hh
@@ -1,6 +1,8 @@
 #ifndef ENTT_VIEW_BENCHMARK_RUNNER_HH_
 #define ENTT_VIEW_BENCHMARK_RUNNER_HH_
 
+#include <vector>
+
 #include <entt/entity/registry.hpp>
 
 #include "benchmark/BenchmarkRunner.hh"
@@ -9,7 +11,7 @@
 class EnttViewBenchmarkRunner : public BenchmarkRunner
 {
   /// \brief Documentation inherited
-  public: void Init() final;
+  public: void Init(const std::size_t _numEntitiesToModify) final;
 
   /// \brief Documentation inherited
   public: void MakeEntityWithComponents() final;
@@ -17,35 +19,49 @@ class EnttViewBenchmarkRunner : public BenchmarkRunner
   /// \brief Documentation inherited
   public: void EachImplementation() final;
 
+  /// \brief Documentation inherited
+  public: void RemoveAComponent() final;
+
+  /// \brief Documentation inherited
+  public: void AddAComponent() final;
+
   /// \brief Entt registry, which is like an ECM
   private: entt::registry registry;
+
+  /// \brief Keep track of the entities that should have a component removed or
+  /// added
+  private: std::vector<entt::entity> entitiesToModify;
 };
 
-void EnttViewBenchmarkRunner::Init()
+void EnttViewBenchmarkRunner::Init(const std::size_t _numEntitiesToModify)
 {
+  this->numEntitiesToModify = _numEntitiesToModify;
 }
 
 void EnttViewBenchmarkRunner::MakeEntityWithComponents()
 {
-  const auto entity = registry.create();
-  registry.emplace<Name>(entity);
-  registry.emplace<Static>(entity);
-  registry.emplace<LinearVelocity>(entity);
-  registry.emplace<WorldLinearVelocity>(entity);
-  registry.emplace<AngularVelocity>(entity);
-  registry.emplace<WorldAngularVelocity>(entity);
-  registry.emplace<LinearAcceleration>(entity);
-  registry.emplace<WorldLinearAcceleration>(entity);
-  registry.emplace<Pose>(entity);
-  registry.emplace<WorldPose>(entity);
+  const auto entity = this->registry.create();
+  this->registry.emplace<Name>(entity);
+  this->registry.emplace<Static>(entity);
+  this->registry.emplace<LinearVelocity>(entity);
+  this->registry.emplace<WorldLinearVelocity>(entity);
+  this->registry.emplace<AngularVelocity>(entity);
+  this->registry.emplace<WorldAngularVelocity>(entity);
+  this->registry.emplace<LinearAcceleration>(entity);
+  this->registry.emplace<WorldLinearAcceleration>(entity);
+  this->registry.emplace<Pose>(entity);
+  this->registry.emplace<WorldPose>(entity);
+
+  if (this->entitiesToModify.size() < this->numEntitiesToModify)
+    this->entitiesToModify.push_back(entity);
 }
 
 void EnttViewBenchmarkRunner::EachImplementation()
 {
   this->entityCount = 0;
-  auto view = registry.view<Name, Static, LinearVelocity, WorldLinearVelocity,
-       AngularVelocity, WorldAngularVelocity, LinearAcceleration,
-       WorldLinearAcceleration, Pose, WorldPose>();
+  auto view = this->registry.view<Name, Static, LinearVelocity,
+       WorldLinearVelocity, AngularVelocity, WorldAngularVelocity,
+       LinearAcceleration, WorldLinearAcceleration, Pose, WorldPose>();
   view.each(
       [this](const auto /*_entity*/, auto &/*_static*/, auto &/*_linVel*/,
         auto &/*_worldLinVel*/, auto &/*_angularVel*/,
@@ -54,6 +70,18 @@ void EnttViewBenchmarkRunner::EachImplementation()
       {
         this->entityCount++;
       });
+}
+
+void EnttViewBenchmarkRunner::RemoveAComponent()
+{
+  for (auto &entity : this->entitiesToModify)
+    this->registry.remove<LinearVelocity>(entity);
+}
+
+void EnttViewBenchmarkRunner::AddAComponent()
+{
+  for (auto &entity : this->entitiesToModify)
+    this->registry.emplace<LinearVelocity>(entity);
 }
 
 #endif


### PR DESCRIPTION
This PR adds functionality for removing components from entities, and also adds the functionality of adding to entities to views _after_ the initial view creation (for example, perhaps an entity is given a new component some time after the entity was originally created - if this new component now makes this entity match the components for view(s) this entity wasn't a part of before, then the entity is added to these views the next time the views are used).

I've also added tests to compare performance between my implementation, `EnTT`, and `ign-gazebo`'s ECM for the case of frequent component addition/removal. The test results, including insights/takeaways, can be found here: https://github.com/adlarkin/simple_ECM/pull/2#issuecomment-832299870

_For detailed test results covering `Each(...)` performance for entities that don't have components added/removed frequently, see https://github.com/adlarkin/simple_ECM/pull/1#issuecomment-823640295_