### PR TITLE
Performance enhancement to component addition/removal

### DIFF
--- a/include/simpleECM/Components.hh
+++ b/include/simpleECM/Components.hh
@@ -25,6 +25,11 @@ struct BaseComponent
   /// \return The typeId of the derived component
   public: virtual ComponentTypeId DerivedTypeId() const = 0;
 
+  /// \brief Whether this component should be ignored or not. This is used
+  /// internally by the ECM to handle component addition and removal, and should
+  /// not be used outside of the ECM
+  public: bool ignore{false};
+
   public: constexpr const static ComponentTypeId typeId{kInvalidComponent};
 };
 

--- a/include/simpleECM/View.hh
+++ b/include/simpleECM/View.hh
@@ -1,6 +1,7 @@
 #ifndef VIEW_HH_
 #define VIEW_HH_
 
+#include <cstddef>
 #include <tuple>
 #include <unordered_map>
 #include <unordered_set>
@@ -11,10 +12,12 @@ class BaseView
 {
   /// \brief Get the entities that are stored in the view
   /// \return The entities in the view
-  public: std::unordered_set<Entity> Entities() const
+  public: const std::unordered_set<Entity> &Entities() const
   {
     return this->entities;
   }
+
+  public: virtual bool HasComponentData(const Entity &_entity) = 0;
 
   /// \brief Check if an entity is a part of the view
   /// \param[in] _entity The entity
@@ -39,7 +42,7 @@ class BaseView
 
   /// \brief Get all of the new entities that should be added to the view
   /// \return The entities
-  public: std::unordered_set<Entity> NewEntities() const
+  public: const std::unordered_set<Entity> &NewEntities() const
   {
     return this->newEntities;
   }
@@ -65,10 +68,26 @@ class BaseView
   /// \param[in] _typeId The component type
   /// \return true if the view has component data of type _typeId, false
   /// otherwise
-  public: bool virtual HasComponent(const ComponentTypeId &_typeId) const
+  public: bool HasComponent(const ComponentTypeId &_typeId) const
   {
     return this->compTypes.find(_typeId) != this->compTypes.end();
   }
+
+  /// \brief Update the internal data in the view because a component has been
+  /// added to an entity. It is assumed that the entity already is a part of the
+  /// view.
+  /// \param[in] _entity The entity
+  /// \param[in] _typeId The type of component that was added to _entity
+  public: virtual void NotifyComponentAddition(const Entity &_entity,
+              const ComponentTypeId &_typeId) = 0;
+
+  /// \brief Update the internal data in the view because a component has been
+  /// removed to an entity. It is assumed that the entity already is a part of
+  /// the view.
+  /// \param[in] _entity The entity
+  /// \param[in] _typeId The type of component that was removed from _entity
+  public: virtual void NotifyComponentRemoval(const Entity &_entity,
+              const ComponentTypeId &_typeId) = 0;
 
   /// \brief Destructor
   public: virtual ~BaseView()
@@ -83,6 +102,14 @@ class BaseView
 
   /// \brief The component types in the view
   protected: std::unordered_set<ComponentTypeId> compTypes;
+
+  /// \brief A map that keeps track of which components for entities in
+  /// invalidData need to be added back to the entity in order to move the
+  /// entity back to validData.
+  ///
+  /// \sa invalidData
+  protected: std::unordered_map<Entity, std::unordered_set<ComponentTypeId>>
+             missingCompTracker;
 };
 
 template<typename ...ComponentTypeTs>
@@ -96,13 +123,20 @@ class View : public BaseView
     this->compTypes = {ComponentTypeTs::typeId...};
   }
 
+  public: bool HasComponentData(const Entity &_entity)
+  {
+    return this->validData.find(_entity) != this->validData.end() ||
+      this->invalidData.find(_entity) != this->invalidData.end();
+  }
+
   /// \brief Get an entity and its component data. It is assumed that the
   /// entity being requested exists in the view
   /// \param[in] _entity The entity
   /// \return The entity and its component data
+  // TODO return a reference here instead of a copy?
   public: ComponentData EntityComponentData(const Entity &_entity) const
   {
-    return this->data.at(_entity);
+    return this->validData.at(_entity);
   }
 
   /// \brief Add an entity with its component data to the view. It is assunmed
@@ -111,7 +145,7 @@ class View : public BaseView
   /// \param[in] _compPtrs Pointers to the entity's components
   public: void AddEntity(const Entity &_entity, ComponentTypeTs*... _compPtrs)
   {
-    this->data[_entity] = std::make_tuple(_entity, _compPtrs...);
+    this->validData[_entity] = std::make_tuple(_entity, _compPtrs...);
     this->entities.insert(_entity);
   }
 
@@ -120,11 +154,59 @@ class View : public BaseView
   {
     this->newEntities.erase(_entity);
     this->entities.erase(_entity);
-    this->data.erase(_entity);
+    this->validData.erase(_entity);
   }
 
+  /// \brief Documentation inherited
+  public: void NotifyComponentAddition(const Entity &_entity,
+              const ComponentTypeId &_typeId)
+  {
+    auto missingCompsIter = this->missingCompTracker.find(_entity);
+    missingCompsIter->second.erase(_typeId);
+    if (missingCompsIter->second.empty())
+    {
+      this->validData[_entity] = this->invalidData[_entity];
+      this->entities.insert(_entity);
+      this->invalidData.erase(_entity);
+      this->missingCompTracker.erase(_entity);
+    }
+  };
+
+  /// \brief Documentation inherited
+  public: void NotifyComponentRemoval(const Entity &_entity,
+              const ComponentTypeId &_typeId)
+  {
+    // if the component being removed is the first component that causes _entity
+    // to be invalid for this view, move _entity from validData to invalidData
+    // and make sure _entity isn't considered a part of the view
+    if (this->validData.find(_entity) != this->validData.end())
+    {
+      this->invalidData[_entity] = this->validData[_entity];
+      this->validData.erase(_entity);
+      this->entities.erase(_entity);
+      this->missingCompTracker[_entity] = {_typeId};
+    }
+    else
+      this->missingCompTracker[_entity].insert(_typeId);
+  };
+
   /// \brief A map of entities to their component data
-  private: std::unordered_map<Entity, ComponentData> data;
+  private: std::unordered_map<Entity, ComponentData> validData;
+
+  /// \brief A map of invalid entities to their component data. The difference
+  /// between invalidData and validData is that the entities in invalidData were
+  /// once in validData, but they had a component removed, so the entity no
+  /// longer meets the component requirements of the view. If the missing
+  /// component data is ever added back to an entitiy in invalidData, then this
+  /// entity will be moved back to validData
+  ///
+  /// The reason for moving entities with missing components to invalidData
+  /// instead of completely deleting them is because tuple creation can be
+  /// costly, so this approach is used instead to maintain performance (the
+  /// tradeoff of mainting performance is increased complexity and memory usage)
+  ///
+  /// \sa missingCompTracker
+  private: std::unordered_map<Entity, ComponentData> invalidData;
 };
 
 #endif


### PR DESCRIPTION
I'm using an "ignore" flag for components to help keep track of valid/invalid `entity <-> component tuple data` in views so that adding components and updating views doesn't take as long